### PR TITLE
TAL-12 Maven preferences as online by default

### DIFF
--- a/main/plugins/org.talend.rcp.branding.esbstandard/plugin_customization.ini
+++ b/main/plugins/org.talend.rcp.branding.esbstandard/plugin_customization.ini
@@ -1,4 +1,4 @@
 org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP=true
 org.eclipse.ui/KEY_CONFIGURATION_ID=org.talend.core.scheme
-org.eclipse.m2e.core/eclipse.m2.offline=true
+org.eclipse.m2e.core/eclipse.m2.offline=false
 org.eclipse.equinox.p2.ui.sdk.scheduler/enabled=false


### PR DESCRIPTION
What is the current behavior? (You can also link to an open issue here)
Maven offline when lauching Talaxie

What is the new behavior?
Maven online when lauching Talaxie